### PR TITLE
chore: fix  prettier error return delete...

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -13,6 +13,12 @@ module.exports = {
       },
     },
   ],
+  'prettier/prettier': [
+    'error',
+    {
+      endOfLine: 'auto',
+    },
+  ],
   arrowParens: 'always',
   trailingComma: 'all',
   useTabs: false,


### PR DESCRIPTION
<img width="717" alt="截圖 2022-06-16 下午10 08 38" src="https://user-images.githubusercontent.com/46858104/174090217-c07f4151-02db-412f-a8ec-26c5618b1d09.png">

請問有人遇到這個 prettier error 嗎？ 是否可以 enable 掉 🤣