### PR TITLE
feat: dispath helper add resturant category and dispatch to Dict

### DIFF
--- a/src/views/Dispatch/RestaurantList/index.vue
+++ b/src/views/Dispatch/RestaurantList/index.vue
@@ -1,8 +1,7 @@
 <script setup>
-import { Button, NavBar } from 'vant'
+import { NavBar } from 'vant'
 import { onMounted } from 'vue'
 import useDispatchInfo from '@/views/Dispatch/store'
-import ContainerOnloadCard from '@/components/ContainerOnloadRecord/ContainerOnloadCard.vue'
 
 const dispatchStore = useDispatchInfo()
 onMounted(() => {
@@ -11,26 +10,6 @@ onMounted(() => {
 </script>
 
 <template>
-  <NavBar safe-area-inset-top fixed title="派工單" />
-  <div class="bg-main bg-opacity-5 h-screen">
-    <ContainerOnloadCard v-for="dispatch in dispatchStore.dispatchs" :key="dispatch.id" v-bind="dispatch">
-      <div class="flex justify-around w-100 bg-white p-4">
-        <Button
-          size="mini"
-          round
-          plain
-          type="primary"
-          class="border-2 border-solid border-primary text-primary px-3 py-1"
-        >
-          預冷溫度
-        </Button>
-        <Button size="mini" round class="border-2 border-solid border-emerald-500 bg-emerald-500 text-white px-3 py-1">
-          容器裝車紀錄
-        </Button>
-        <Button size="mini" round class="border-2 border-solid border-neutral-500 bg-neutral-500 text-white px-3 py-1">
-          餐廳明細
-        </Button>
-      </div>
-    </ContainerOnloadCard>
-  </div>
+  <NavBar safe-area-inset-top fixed title="派工單id" />
+  <div class="bg-main bg-opacity-5 h-screen">餐廳明細列表頁面</div>
 </template>

--- a/src/views/Dispatch/RestaurantList/index.vue
+++ b/src/views/Dispatch/RestaurantList/index.vue
@@ -1,0 +1,36 @@
+<script setup>
+import { Button, NavBar } from 'vant'
+import { onMounted } from 'vue'
+import useDispatchInfo from '@/views/Dispatch/store'
+import ContainerOnloadCard from '@/components/ContainerOnloadRecord/ContainerOnloadCard.vue'
+
+const dispatchStore = useDispatchInfo()
+onMounted(() => {
+  console.log(dispatchStore)
+})
+</script>
+
+<template>
+  <NavBar safe-area-inset-top fixed title="派工單" />
+  <div class="bg-main bg-opacity-5 h-screen">
+    <ContainerOnloadCard v-for="dispatch in dispatchStore.dispatchs" :key="dispatch.id" v-bind="dispatch">
+      <div class="flex justify-around w-100 bg-white p-4">
+        <Button
+          size="mini"
+          round
+          plain
+          type="primary"
+          class="border-2 border-solid border-primary text-primary px-3 py-1"
+        >
+          預冷溫度
+        </Button>
+        <Button size="mini" round class="border-2 border-solid border-emerald-500 bg-emerald-500 text-white px-3 py-1">
+          容器裝車紀錄
+        </Button>
+        <Button size="mini" round class="border-2 border-solid border-neutral-500 bg-neutral-500 text-white px-3 py-1">
+          餐廳明細
+        </Button>
+      </div>
+    </ContainerOnloadCard>
+  </div>
+</template>

--- a/src/views/Dispatch/helper/index.js
+++ b/src/views/Dispatch/helper/index.js
@@ -1,0 +1,48 @@
+export const RestaurantStatusType = {
+  PENDING_DELIVERY: 'PENDING_DELIVERY',
+  DELIVERING: 'DELIVERING',
+  ARRIVAL: 'ARRIVAL',
+  TEMP_CONFIRMATION: 'TEMP_CONFIRMATION',
+  DELIVERY_COMPLETED: 'DELIVERY_COMPLETED',
+  DELAY: 'DELAY',
+  UNABLE_DELIVERY: 'UNABLE_DELIVERY',
+}
+
+export const RestaurantStatusNumberToType = {
+  0: RestaurantStatusType.PENDING_DELIVERY,
+  1: RestaurantStatusType.DELIVERING,
+  2: RestaurantStatusType.ARRIVAL,
+  3: RestaurantStatusType.TEMP_CONFIRMATION,
+  4: RestaurantStatusType.DELIVERY_COMPLETED,
+  11: RestaurantStatusType.DELAY,
+  12: RestaurantStatusType.UNABLE_DELIVERY,
+}
+
+export const dispatchToDict = (dispatchs) => {
+  if (!dispatchs || dispatchs.length === 0) return null
+  return dispatchs.reduce(
+    (dict, curr) => ({
+      ...dict,
+      [curr.id]: curr,
+    }),
+    {},
+  )
+}
+
+export const resturantByStatus = (resturants) => {
+  if (!resturants || resturants.length === 0) return null
+  return resturants.reduce((prev, curr) => {
+    const type = RestaurantStatusNumberToType[curr.status]
+    if (prev[type]) {
+      return {
+        ...prev,
+        [type]: prev[type].concat(curr),
+      }
+    } else {
+      return {
+        ...prev,
+        [type]: [curr],
+      }
+    }
+  }, {})
+}

--- a/src/views/Dispatch/helper/index.spec.js
+++ b/src/views/Dispatch/helper/index.spec.js
@@ -245,7 +245,7 @@ describe('resturantByStatus', () => {
   test('resturantByStatus should be null when stores is null', () => {
     expect(resturantByStatus(null)).toEqual(null)
   })
-  test('should be null when dispatch is empty', () => {
+  test('should be null when stores is empty', () => {
     expect(resturantByStatus([])).toEqual(null)
   })
   test('should be categorized correctly', () => {

--- a/src/views/Dispatch/helper/index.spec.js
+++ b/src/views/Dispatch/helper/index.spec.js
@@ -1,0 +1,254 @@
+import { expect, describe, test } from 'vitest'
+import { dispatchToDict, resturantByStatus } from '.'
+
+const mockStores = [
+  {
+    id: 'DS62a976485a631',
+    bu: 'MD',
+    number: '00000506',
+    name: 'test-store2',
+    address: 'test-address2',
+    tel: '03-3239975',
+    arrival_time: '2022-06-16 13:30:00',
+    sort: 1,
+    status: 1,
+  },
+  {
+    id: 'DS62a976485a632',
+    bu: 'MD',
+    number: '00000506',
+    name: 'test-store2',
+    address: 'test-address2',
+    tel: '03-3239975',
+    arrival_time: '2022-06-16 13:30:00',
+    sort: 1,
+    status: 0,
+  },
+  {
+    id: 'DS62a976485a633',
+    bu: 'MD',
+    number: '00000506',
+    name: 'test-store2',
+    address: 'test-address2',
+    tel: '03-3239975',
+    arrival_time: '2022-06-16 13:30:00',
+    sort: 1,
+    status: 0,
+  },
+  {
+    id: 'DS62a976485a634',
+    bu: 'MD',
+    number: '00000506',
+    name: 'test-store2',
+    address: 'test-address2',
+    tel: '03-3239975',
+    arrival_time: '2022-06-16 13:30:00',
+    sort: 1,
+    status: 4,
+  },
+  {
+    id: 'DS62a976485a635',
+    bu: 'MD',
+    number: '00000506',
+    name: 'test-store2',
+    address: 'test-address2',
+    tel: '03-3239975',
+    arrival_time: '2022-06-16 13:30:00',
+    sort: 1,
+    status: 2,
+  },
+  {
+    id: 'DS62a976485a636',
+    bu: 'MD',
+    number: '00000506',
+    name: 'test-store2',
+    address: 'test-address2',
+    tel: '03-3239975',
+    arrival_time: '2022-06-16 13:30:00',
+    sort: 1,
+    status: 2,
+  },
+]
+
+const mockStoreByStatus = {
+  PENDING_DELIVERY: [
+    {
+      id: 'DS62a976485a632',
+      bu: 'MD',
+      number: '00000506',
+      name: 'test-store2',
+      address: 'test-address2',
+      tel: '03-3239975',
+      arrival_time: '2022-06-16 13:30:00',
+      sort: 1,
+      status: 0,
+    },
+    {
+      id: 'DS62a976485a633',
+      bu: 'MD',
+      number: '00000506',
+      name: 'test-store2',
+      address: 'test-address2',
+      tel: '03-3239975',
+      arrival_time: '2022-06-16 13:30:00',
+      sort: 1,
+      status: 0,
+    },
+  ],
+  DELIVERING: [
+    {
+      id: 'DS62a976485a631',
+      bu: 'MD',
+      number: '00000506',
+      name: 'test-store2',
+      address: 'test-address2',
+      tel: '03-3239975',
+      arrival_time: '2022-06-16 13:30:00',
+      sort: 1,
+      status: 1,
+    },
+  ],
+  ARRIVAL: [
+    {
+      id: 'DS62a976485a635',
+      bu: 'MD',
+      number: '00000506',
+      name: 'test-store2',
+      address: 'test-address2',
+      tel: '03-3239975',
+      arrival_time: '2022-06-16 13:30:00',
+      sort: 1,
+      status: 2,
+    },
+    {
+      id: 'DS62a976485a636',
+      bu: 'MD',
+      number: '00000506',
+      name: 'test-store2',
+      address: 'test-address2',
+      tel: '03-3239975',
+      arrival_time: '2022-06-16 13:30:00',
+      sort: 1,
+      status: 2,
+    },
+  ],
+  DELIVERY_COMPLETED: [
+    {
+      id: 'DS62a976485a634',
+      bu: 'MD',
+      number: '00000506',
+      name: 'test-store2',
+      address: 'test-address2',
+      tel: '03-3239975',
+      arrival_time: '2022-06-16 13:30:00',
+      sort: 1,
+      status: 4,
+    },
+  ],
+}
+
+const mockDispatch = [
+  {
+    id: 'DL62a976485009b',
+    dc: 'NDC',
+    no: 'N4031-12-2-E01',
+    date: '10/14/2021',
+    departure_time: '2022-06-16 13:13:00',
+    temp_zone: 'F,C,D',
+    cube: 401.06,
+    status: 3,
+    is_loading: 1,
+    sort: 0,
+    store: [
+      {
+        id: 'DS62a976485a638',
+        bu: 'MD',
+        number: '00000506',
+        name: 'test-store',
+        address: 'test-address',
+        tel: '03-3239975',
+        arrival_time: '2022-06-16 13:30:00',
+        sort: 1,
+        status: 2,
+      },
+    ],
+  },
+  {
+    id: 'DL62a976485009c',
+    dc: 'NDC',
+    no: 'N4031-12-2-E01',
+    date: '10/14/2021',
+    departure_time: '2022-06-16 13:13:00',
+    temp_zone: 'F,C,D',
+    cube: 401.06,
+    status: 3,
+    is_loading: 1,
+    sort: 0,
+    store: mockStores,
+  },
+]
+
+const mockDispatchDict = {
+  DL62a976485009b: {
+    id: 'DL62a976485009b',
+    dc: 'NDC',
+    no: 'N4031-12-2-E01',
+    date: '10/14/2021',
+    departure_time: '2022-06-16 13:13:00',
+    temp_zone: 'F,C,D',
+    cube: 401.06,
+    status: 3,
+    is_loading: 1,
+    sort: 0,
+    store: [
+      {
+        id: 'DS62a976485a638',
+        bu: 'MD',
+        number: '00000506',
+        name: 'test-store',
+        address: 'test-address',
+        tel: '03-3239975',
+        arrival_time: '2022-06-16 13:30:00',
+        sort: 1,
+        status: 2,
+      },
+    ],
+  },
+  DL62a976485009c: {
+    id: 'DL62a976485009c',
+    dc: 'NDC',
+    no: 'N4031-12-2-E01',
+    date: '10/14/2021',
+    departure_time: '2022-06-16 13:13:00',
+    temp_zone: 'F,C,D',
+    cube: 401.06,
+    status: 3,
+    is_loading: 1,
+    sort: 0,
+    store: mockStores,
+  },
+}
+
+describe('dispatchToDict', () => {
+  test('dict should be null when dispatch is null', () => {
+    expect(dispatchToDict(null)).toEqual(null)
+  })
+  test('dict should be null when dispatch is empty', () => {
+    expect(dispatchToDict([])).toEqual(null)
+  })
+  test('dispatch should be converted to Dict correctly', () => {
+    expect(dispatchToDict(mockDispatch)).toEqual(mockDispatchDict)
+  })
+})
+
+describe('resturantByStatus', () => {
+  test('resturantByStatus should be null when stores is null', () => {
+    expect(resturantByStatus(null)).toEqual(null)
+  })
+  test('should be null when dispatch is empty', () => {
+    expect(resturantByStatus([])).toEqual(null)
+  })
+  test('should be categorized correctly', () => {
+    expect(resturantByStatus(mockStores)).toEqual(mockStoreByStatus)
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,6 @@
-import { fileURLToPath, URL } from 'url'
+/// <reference types="vitest" />
 import { defineConfig } from 'vite'
+import { fileURLToPath, URL } from 'url'
 import styleImport, { VantResolve } from 'vite-plugin-style-import'
 import vue from '@vitejs/plugin-vue'
 
@@ -35,6 +36,11 @@ export default defineConfig(() => {
           changeOrigin: true,
           rewrite: (path) => path.replace(/^\/api/, ''),
         },
+      },
+    },
+    test: {
+      coverage: {
+        reporter: ['text', 'json', 'html'],
       },
     },
   }


### PR DESCRIPTION
## motivation
1. 由於後端api一些狀態會用數字表示，但這對前端來說其實不太好維護
所以我會在前端統一將數字轉換成相對應的Type，可以參考RestaurantStatusNumberToType

2. store會根據狀態來做分類所以特別抽出來寫function處理

3. store這命名跟前端的狀態管理有衝突，會統一改成restaurant